### PR TITLE
Add userAgent to terminate session DTO

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -258,11 +258,9 @@ export class AuthController {
   @ApiMutationErrorResponses()
   async terminateSpecificSession(
     @CurrentUser('userId') userId: string,
-    @Req() req: Request,
     @Body() dto: TerminateSessionDto,
   ) {
-    const userAgent = req.headers['user-agent'] || '';
-    const ip = dto.ip;
+    const { ip, userAgent } = dto;
 
     const result = await this.sessionService.terminateSpecificSession(
       userId,

--- a/src/auth/dto/terminate-session.dto.ts
+++ b/src/auth/dto/terminate-session.dto.ts
@@ -6,4 +6,11 @@ export class TerminateSessionDto {
   @IsIP('4')
   @IsNotEmpty()
   ip: string;
+
+  @ApiProperty({
+    example: 'Mozilla/5.0...',
+    description: 'User-Agent сесії',
+  })
+  @IsNotEmpty()
+  userAgent: string;
 }


### PR DESCRIPTION
## Summary
- extend `TerminateSessionDto` with `userAgent`
- update `AuthController.terminateSpecificSession` to read `userAgent` from the body

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e83d28bb8832d945d447b43be9500