### PR TITLE
Use env for JWT expiry

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -20,7 +20,7 @@ import { SessionService } from './session.service';
       useFactory: (config: ConfigService) => ({
         secret: config.get<string>('JWT_ACCESS_SECRET'),
         signOptions: {
-          expiresIn: '15m',
+          expiresIn: config.get<string>('JWT_ACCESS_EXPIRES_IN', '15m'),
         },
       }),
     }),


### PR DESCRIPTION
## Summary
- make JWT access token expiry configurable via JWT_ACCESS_EXPIRES_IN

## Testing
- `npm test` *(fails: Module '@prisma/client' has no exported member 'Role')*

------
https://chatgpt.com/codex/tasks/task_e_684e8ac0bdcc832db05cbe5e2beddfa5