### PR TITLE
Fix CurrentUser decorator typing

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import {
   Controller,
   Get,
   HttpCode,
+  UnauthorizedException,
   NotFoundException,
   Param,
   Post,
@@ -211,7 +212,11 @@ export class AuthController {
     type: TerminateCountResponseDto,
   })
   @ApiMutationErrorResponses()
-  async terminateOtherSessions(@CurrentUser() user: UserFromJwt) {
+  async terminateOtherSessions(@CurrentUser() user: UserFromJwt | undefined) {
+    if (!user) {
+      throw new UnauthorizedException();
+    }
+
     const result = await this.sessionService.terminateOtherSessions(
       user.userId,
       user.sid,

--- a/src/auth/decorators/current-user.decorator.ts
+++ b/src/auth/decorators/current-user.decorator.ts
@@ -2,9 +2,12 @@ import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import { Request } from 'express';
 import { UserFromJwt } from '../types/user-from-jwt';
 export const CurrentUser = createParamDecorator(
-  (data: keyof UserFromJwt | undefined, ctx: ExecutionContext): any => {
+  (
+    data: keyof UserFromJwt | undefined,
+    ctx: ExecutionContext,
+  ): UserFromJwt | undefined => {
     const request = ctx.switchToHttp().getRequest<Request>();
-    const user = request.user as UserFromJwt;
+    const user = request.user as UserFromJwt | undefined;
 
     return data ? user?.[data] : user;
   },


### PR DESCRIPTION
## Summary
- return `UserFromJwt | undefined` from `CurrentUser` decorator
- handle optional value in auth controller

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8b75a068832d99d48d8ee498246b