### PR TITLE
Fix current user decorator type

### DIFF
--- a/src/auth/decorators/current-user.decorator.ts
+++ b/src/auth/decorators/current-user.decorator.ts
@@ -5,7 +5,7 @@ export const CurrentUser = createParamDecorator(
   (
     data: keyof UserFromJwt | undefined,
     ctx: ExecutionContext,
-  ): UserFromJwt | undefined => {
+  ): UserFromJwt[keyof UserFromJwt] | UserFromJwt | undefined => {
     const request = ctx.switchToHttp().getRequest<Request>();
     const user = request.user as UserFromJwt | undefined;
 


### PR DESCRIPTION
## Summary
- adjust CurrentUser decorator return type to cover property access return types

## Testing
- `npm test` *(fails: Module '@prisma/client' has no exported member 'Role')*


------
https://chatgpt.com/codex/tasks/task_e_684e9001fcd8832db61cc1269fe5c584