### PR TITLE
Fix PrismaService logger dependency

### DIFF
--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -11,7 +11,9 @@ export class PrismaService
   extends PrismaClient
   implements OnModuleInit, OnModuleDestroy
 {
-  constructor(private readonly logger: Logger) {
+  private readonly logger = new Logger(PrismaService.name);
+
+  constructor() {
     super();
   }
 


### PR DESCRIPTION
## Summary
- fix PrismaService dependency injection error by instantiating Logger internally

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' and many lint errors)*
- `npm test` *(fails: Prisma client not generated)*

------
https://chatgpt.com/codex/tasks/task_e_684e915a8500832db94207dd89b2c57d