### PR TITLE
Fix throttler options type

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,10 @@
 import { Module } from '@nestjs/common';
 import { APP_GUARD } from '@nestjs/core';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import {
+  ThrottlerModule,
+  ThrottlerGuard,
+  ThrottlerModuleOptions,
+} from '@nestjs/throttler';
 
 import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './auth/auth.module';
@@ -29,10 +33,12 @@ import { ScheduleModule } from '@nestjs/schedule';
     ThrottlerModule.forRootAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
-      useFactory: (config: ConfigService) => ({
-        ttl: config.get<number>('THROTTLE_TTL', 60),
-        limit: config.get<number>('THROTTLE_LIMIT', 10),
-      }),
+      useFactory: (config: ConfigService): ThrottlerModuleOptions => [
+        {
+          ttl: config.get<number>('THROTTLE_TTL', 60),
+          limit: config.get<number>('THROTTLE_LIMIT', 10),
+        },
+      ],
     }),
     ScheduleModule.forRoot(),
     PrismaModule,


### PR DESCRIPTION
## Summary
- import `ThrottlerModuleOptions`
- update the `forRootAsync` factory to return a valid `ThrottlerModuleOptions` array

## Testing
- `npm run format`
- `npm run lint` *(fails: 228 problems)*

------
https://chatgpt.com/codex/tasks/task_e_684eaf62a8a8832d82c9c40c688d21e6