### PR TITLE
Configure throttle skips for authenticated routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ npm run start:dev
 
 Swagger documentation will be available at `${BASE_URL}/api/docs` once the server starts.
 
+## Throttling
+
+The API enforces a global request rate limit controlled by `THROTTLE_TTL` and
+`THROTTLE_LIMIT`. Endpoints that require authentication are exempt from this
+limit. The following routes skip throttling:
+
+- `POST /auth/logout`
+- `GET /auth/me`
+- `GET /auth/:userId/sessions`
+- `GET /auth/sessions/active`
+- `POST /auth/sessions/terminate-others`
+- `GET /auth/sessions/me`
+- `POST /auth/sessions/terminate`
+- All routes under `/users/*`
+
 ## License
 
 This project is released under the MIT License.

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -34,6 +34,7 @@ import {
 import { Tokens } from './types/jwt.types';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { CurrentUser } from './decorators/current-user.decorator';
+import { SkipThrottle } from '@nestjs/throttler';
 
 import { TokenResponseDto } from './dto/token-response.dto';
 import { MeResponseDto } from './dto/me-response.dto';
@@ -121,6 +122,7 @@ export class AuthController {
 
   @Post('logout')
   @UseGuards(JwtAuthGuard)
+  @SkipThrottle()
   @ApiBearerAuth()
   @HttpCode(200)
   @ApiOperation({
@@ -143,6 +145,7 @@ export class AuthController {
 
   @Get('me')
   @UseGuards(JwtAuthGuard)
+  @SkipThrottle()
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Отримати інформацію про себе' })
   @ApiOkResponse({
@@ -160,6 +163,7 @@ export class AuthController {
 
   @Get(':userId/sessions')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @SkipThrottle()
   @Roles(Role.ADMIN, Role.MODERATOR)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Список активних сесій користувача' })
@@ -182,6 +186,7 @@ export class AuthController {
 
   @Get('sessions/active')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @SkipThrottle()
   @Roles(Role.ADMIN, Role.MODERATOR)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Список активних сесій поточного користувача' })
@@ -204,6 +209,7 @@ export class AuthController {
 
   @Post('sessions/terminate-others')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @SkipThrottle()
   @Roles(Role.ADMIN, Role.MODERATOR)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Завершити всі інші сесії, крім поточної' })
@@ -229,6 +235,7 @@ export class AuthController {
 
   @Get('sessions/me')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @SkipThrottle()
   @Roles(Role.ADMIN, Role.MODERATOR)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Список всіх сесій користувача' })
@@ -253,6 +260,7 @@ export class AuthController {
 
   @Post('sessions/terminate')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @SkipThrottle()
   @Roles(Role.ADMIN, Role.MODERATOR)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Завершити конкретну сесію за IP та User-Agent' })

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -25,6 +25,7 @@ import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/roles.guard';
 import { Roles } from 'src/auth/decorators/roles.decorator';
 import { Role } from '@prisma/client';
+import { SkipThrottle } from '@nestjs/throttler';
 import { UpdateUserDto } from './dto/update-user.dto';
 
 @ApiTags('users')
@@ -34,6 +35,7 @@ export class UsersController {
 
   @Get('id/:id')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @SkipThrottle()
   @Roles(Role.ADMIN, Role.MODERATOR)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Отримати користувача за ID' })
@@ -52,6 +54,7 @@ export class UsersController {
 
   @Get('email/:email')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @SkipThrottle()
   @Roles(Role.ADMIN, Role.MODERATOR)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Пошук користувача за email' })
@@ -70,6 +73,7 @@ export class UsersController {
 
   @Patch(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @SkipThrottle()
   @Roles(Role.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Оновити користувача' })
@@ -83,6 +87,7 @@ export class UsersController {
 
   @Delete(':id')
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @SkipThrottle()
   @Roles(Role.ADMIN)
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Видалити користувача' })


### PR DESCRIPTION
## Summary
- exempt authenticated routes in AuthController and UsersController from throttling
- document throttling behavior in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb4c515ec832db2fac348433f8961