### PR TITLE
Add postinstall script for Prisma

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",


### PR DESCRIPTION
## Summary
- ensure Prisma types are generated after installing packages

## Testing
- `npm install` *(fails: unable to fetch Prisma binaries due to network restrictions)*
- `npm test` *(fails: test suites cannot run without generated Prisma client)*


------
https://chatgpt.com/codex/tasks/task_e_684ec1ee419c832db76077f5f3acb697