### PR TITLE
Implement logout termination timestamp

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -133,14 +133,16 @@ export class AuthController {
     type: LogoutResponseDto,
   })
   @ApiMutationErrorResponses()
-  async logout(@CurrentUser('userId') userId: string) {
+  async logout(
+    @CurrentUser('userId') userId: string,
+  ): Promise<LogoutResponseDto> {
     const result = await this.authService.logout(userId);
 
-    if (!result.loggedOut) {
+    if (!result) {
       throw new BadRequestException('Користувач вже вийшов із системи');
     }
 
-    return result;
+    return new LogoutResponseDto(result);
   }
 
   @Get('me')

--- a/src/auth/dto/logout-response.dto.ts
+++ b/src/auth/dto/logout-response.dto.ts
@@ -9,4 +9,9 @@ export class LogoutResponseDto {
     description: 'Час завершення сесій',
   })
   terminatedAt: string | null;
+
+  constructor(data: { loggedOut: boolean; terminatedAt: string | null }) {
+    this.loggedOut = data.loggedOut;
+    this.terminatedAt = data.terminatedAt;
+  }
 }


### PR DESCRIPTION
## Summary
- enhance logout response with timestamp
- return `null` if nothing was terminated
- provide DTO class constructor and use it in controller

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm test` *(fails: jest: not found)*
- `npm run build` *(fails: nest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ec2ffba88832d8870751541f8231a