### PR TITLE
Update README with Prisma installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ This project provides the API and database layer for a Multi User Dungeon (MUD) 
    ```bash
    npm install
    ```
+   > **Note**: Prisma requires internet access during installation to download
+   > its engine binaries. For offline environments, prebuild or cache the
+   > Prisma engines.
 
 2. Copy `.env.example` to `.env` and adjust the values as needed:
 


### PR DESCRIPTION
## Summary
- document that Prisma downloads engine binaries during installation
- suggest prebuilding or caching those engines for offline environments

## Testing
- `npm install` *(fails: could not fetch Prisma engine binaries)*

------
https://chatgpt.com/codex/tasks/task_e_684ee73480a4832d9058ec8206ed3125