### PR TITLE
Add env vars for logger configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,8 @@ THROTTLE_LIMIT=10
 # Cleanup settings
 TOKEN_CLEANUP_DAYS=7
 
+
+# Logger settings
+LOG_DIR=logs
+LOG_MAX_SIZE=10m
+LOG_MAX_FILES=14d

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ This project provides the API and database layer for a Multi User Dungeon (MUD) 
   `TOKEN_CLEANUP_DAYS` setting which defines how old revoked tokens
   must be before removal.
 
+  Logging can be tuned with `LOG_DIR` (log directory), `LOG_MAX_SIZE` (rotate size), and `LOG_MAX_FILES` (retention period).
+
 3. Generate the Prisma client and apply database migrations:
 
    ```bash

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -26,6 +26,9 @@ import { LoggerModule } from './logger/logger.module';
         THROTTLE_TTL: Joi.number().default(60),
         THROTTLE_LIMIT: Joi.number().default(10),
         TOKEN_CLEANUP_DAYS: Joi.number().default(7),
+        LOG_DIR: Joi.string().default("logs"),
+        LOG_MAX_SIZE: Joi.string().default("10m"),
+        LOG_MAX_FILES: Joi.string().default("14d"),
       }),
     }),
     ThrottlerModule.forRootAsync({

--- a/src/logger/winston.config.ts
+++ b/src/logger/winston.config.ts
@@ -24,12 +24,12 @@ export const consoleTransport = new winston.transports.Console({
 });
 
 export const fileTransport = new winston.transports.DailyRotateFile({
-  dirname: 'logs',
+  dirname: process.env.LOG_DIR || 'logs',
   filename: '%DATE%.log',
   datePattern: 'YYYY-MM-DD',
   zippedArchive: true,
-  maxSize: '10m',
-  maxFiles: '14d',
+  maxSize: process.env.LOG_MAX_SIZE || '10m',
+  maxFiles: process.env.LOG_MAX_FILES || '14d',
   format: winston.format.combine(
     winston.format.timestamp(),
     winston.format.json(),


### PR DESCRIPTION
## Summary
- allow configuring logger rotation via `.env`
- document the new `LOG_*` environment variables

## Testing
- `npm install` *(fails: binaries.prisma.sh blocked)*
- `npm test` *(fails: jest can't run without dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f1569c684832d977e606f8e2c94e6