### PR TITLE
Remove deprecated auth DTOs and unused method

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -38,7 +38,6 @@ import { SkipThrottle } from '@nestjs/throttler';
 
 import { TokenResponseDto } from './dto/token-response.dto';
 import { MeResponseDto } from './dto/me-response.dto';
-import { PrismaService } from '../prisma/prisma.service';
 import { extractRequestInfo } from 'src/common/helpers/request-info';
 import { TerminateSessionDto } from './dto/terminate-session.dto';
 import { ActiveSessionDto } from './dto/active-session.dto';
@@ -61,7 +60,6 @@ import { UsersService } from 'src/users/users.service';
 export class AuthController {
   constructor(
     private authService: AuthService,
-    private prisma: PrismaService,
     private sessionService: SessionService,
     private refreshTokenService: RefreshTokenService,
     private usersService: UsersService,

--- a/src/auth/dto/logout.dto.ts
+++ b/src/auth/dto/logout.dto.ts
@@ -1,9 +1,0 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsUUID } from 'class-validator';
-
-export class LogoutDto {
-  @ApiProperty({ example: 'clx123...', description: 'ID користувача' })
-  @IsUUID()
-  @IsNotEmpty()
-  userId: string;
-}

--- a/src/auth/dto/refresh-token.dto.ts
+++ b/src/auth/dto/refresh-token.dto.ts
@@ -1,9 +1,0 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsJWT, IsNotEmpty } from 'class-validator';
-
-export class RefreshTokenDto {
-  @ApiProperty({ example: 'refresh.jwt.token' })
-  @IsJWT()
-  @IsNotEmpty()
-  refreshToken: string;
-}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -43,14 +43,6 @@ export class UsersService {
     });
   }
 
-  async saveRefreshTokenEntry(userId: string, jti: string) {
-    await this.prisma.refreshToken.create({
-      data: {
-        userId,
-        jti,
-      },
-    });
-  }
 
   async findByEmail(email: string): Promise<User | null> {
     return this.prisma.user.findUnique({ where: { email } });


### PR DESCRIPTION
## Summary
- delete unused `LogoutDto` and `RefreshTokenDto`
- drop `saveRefreshTokenEntry` from `UsersService`
- remove unused `PrismaService` from `AuthController`

## Testing
- `npm test` *(fails: cannot find some modules)*

------
https://chatgpt.com/codex/tasks/task_e_684f31f2dfbc832d9c889c98aba4563a